### PR TITLE
READY : Fix prerelease build on Windows

### DIFF
--- a/.github/workflows/GypPrebuild.yml
+++ b/.github/workflows/GypPrebuild.yml
@@ -48,10 +48,10 @@ jobs :
     - run : npm list
       continue-on-error : true
     - run : npm run node-pre-gyp-build
-    # - run : npm run node-pre-gyp-package && npm run node-pre-gyp-github-release
-    - name : Release module
-      uses : Wandalen/wretry.action@v1.0.11
-      with :
-        command : npm run node-pre-gyp-package && npm run node-pre-gyp-github-release
-        attempt_limit : 3
-        attempt_delay: 1000
+    - run : npm run node-pre-gyp-package && npm run node-pre-gyp-github-release
+    # - name : Release module
+    #   uses : Wandalen/wretry.action@v1.0.11
+    #   with :
+    #     command : npm run node-pre-gyp-package && npm run node-pre-gyp-github-release
+    #     attempt_limit : 3
+    #     attempt_delay: 1000


### PR DESCRIPTION
The reasons of downgrade : 
- [Github use new version of Njs](https://github.com/actions/virtual-environments/issues/4446)
- Github workflow environment can`t build binary submodules if some module has more than one binary submodule ( [issue](https://github.com/nodejs/node-gyp/issues/2484) ).

`wretry.action` should work after new binary release of the module.